### PR TITLE
Point JupyterBook to correct repository

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,7 +12,7 @@ execute:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
+  url: https://github.com/uwescience/SciPy2024-GitHubActionsTutorial  # Online location of your book
   path_to_book: docs  # Optional path to your book, relative to the repository root
   branch: lesson_content  # Which branch of the repository should be used when creating links (optional)
 


### PR DESCRIPTION
I'm curious about `branch: lesson_content`. Could all the content just sit in the 'main' branch under docs?